### PR TITLE
Add support for Windows platform and some bug fixes

### DIFF
--- a/src/macad_gym/core/sensors/derived_sensors.py
+++ b/src/macad_gym/core/sensors/derived_sensors.py
@@ -16,7 +16,7 @@ class LaneInvasionSensor(object):
         self.offlane = 0  # count of off lane
         self.offroad = 0  # count of off road
         world = self._parent.get_world()
-        bp = world.get_blueprint_library().find('sensor.other.lane_detector')
+        bp = world.get_blueprint_library().find('sensor.other.lane_invasion')
         self.sensor = world.spawn_actor(
             bp, carla.Transform(), attach_to=self._parent)
         # We need to pass the lambda a weak reference to self to avoid circular


### PR DESCRIPTION
# 1. Why

I'm currently using macad-gym on a Windows 11 device with the latest version of Carla (0.9.13). Seems like macad-gym does not support Windows at all, and a couple of API from Carla have whether been changed or deprecated. I've made some refractor to make things work again (mainly focusing on the `multi_env.py` file)

# 2. Changes

I've made a couple of changes as below.

## 2.1 Windows support

I've referred to the issue [[Windows Support]module 'os' has no attribute 'getpgid' #32](https://github.com/praveen-palanisamy/macad-gym/issues/32#issue-808836844). The solution given in comment can indeed make the code run. However, the `cleanup()` function can't close up both `CarlaUE4.exe` and `CarlaUE4-Win64-Shipping.exe` (the latter is the real server which is a subprocess of the CarlaUE4.exe). So instead, I call the `taskkill -F /T /PID {pid}` to recursively kill all related processes.

## 2.2 Stuck at `env.reset()`

The problem addressed in [Also stuck in env.reset() in example #63](https://github.com/praveen-palanisamy/macad-gym/issues/63#issue-1213239396) is due to the failure of `carla.Client()` establishing connection with Carla-server. This problem is caused by two reasons:

https://github.com/praveen-palanisamy/macad-gym/blob/38884ac4bc7fb2e91a865950cff4eeadeed02f60/src/macad_gym/carla/multi_env.py#L453-L469

These lines of code starting a Carla subprocess using `subprocess.Popen` is incorrect, when using a list to pass arguments, each arg should be split up. I.e., `["-carla-server", "-carla-rpc-port=2000"]` is ok, but `["-carla-server -carla-rpc-port=2000"]` is not. This problem will cause the Carla-server not starting with the specified port.

Another thing is the Client side failed to connect to server, related code is here:

https://github.com/praveen-palanisamy/macad-gym/blob/38884ac4bc7fb2e91a865950cff4eeadeed02f60/src/macad_gym/carla/multi_env.py#L478-L487

The above code test `client.get_server_version()` immediately after its creation, which can lead to a race between the socket connection and communication. Simply `time.sleep(2)` after `carla.Client()` will solve the problem.

## 2.3 Deprecated/Changed API

1. `world.tick()` and `world.wait_for_tick()` could lead to a race condition, [Fixes for synchronous mode](https://github.com/carla-simulator/carla/pull/1803) PR has already make `tick()` function synchronized.
2. Carla no longer support passing map as argument in command-line since 0.9.6+. The correct way to do is using the Client-API, `client.load_world(map)`. I've added this in `init_server` function.

## 2.4 Minor bug fixes

1. `carla.WeatherParameters.cloudiness` instead of `carla.WeatherParameters.cloudyness`
2. The cameras will get destroyed twice in function `_clean_world`, this doesn't affect running but will raise exceptions. I've commented out one destroy process.