### PR TITLE
Fixed manual_control usage

### DIFF
--- a/src/macad_gym/carla/multi_env.py
+++ b/src/macad_gym/carla/multi_env.py
@@ -965,11 +965,9 @@ class MultiCarlaEnv(*MultiAgentEnvBases):
                         self, actor_config["auto_control"])
                     self._manual_controller.actor_id = actor_id
                     
-                    manual_control_hud = HUD(self._render_x_res, self._render_y_res)
-                    self.world.on_tick(manual_control_hud.on_world_tick)
-                    
+                    self.world.on_tick(self._hud.on_world_tick)
                     self._manual_control_camera_manager = CameraManager(
-                        self._actors[actor_id], manual_control_hud)
+                        self._actors[actor_id], self._hud)
                     self._manual_control_camera_manager.set_sensor(
                         CAMERA_TYPES['rgb'].value - 1, pos=2, notify=False
                     )

--- a/src/macad_gym/core/sensors/camera_manager.py
+++ b/src/macad_gym/core/sensors/camera_manager.py
@@ -139,9 +139,9 @@ class CameraManager(object):
         self._hud.notification('Recording %s' %
                                ('On' if self._recording else 'Off'))
 
-    def render(self, display):
+    def render(self, display, render_pose=(0, 0)):
         if self._surface is not None:
-            display.blit(self._surface, (0, 0))
+            display.blit(self._surface, render_pose)
 
     @staticmethod
     def _parse_image(weak_self, image):

--- a/src/macad_gym/core/sensors/camera_manager.py
+++ b/src/macad_gym/core/sensors/camera_manager.py
@@ -21,6 +21,7 @@ CAMERA_TYPES = Enum('CameraType', ['rgb',
 class CameraManager(object):
     """This class from carla, manual_control.py
     """
+
     def __init__(self, parent_actor, hud):
         self.image = None  # need image to encode obs.
         self.image_list = []  # for save images later.
@@ -34,9 +35,14 @@ class CameraManager(object):
         self._camera_transforms = [
             carla.Transform(carla.Location(x=1.8, z=1.7)),
             carla.Transform(carla.Location(x=-5.5, z=2.8),
-                            carla.Rotation(pitch=-15))
+                            carla.Rotation(pitch=-15)),
+            carla.Transform(carla.Location(
+                x=-2.0*(0.5 + self._parent.bounding_box.extent.x),
+                y=0.0,
+                z=2.0*(0.5 + self._parent.bounding_box.extent.z)),
+                carla.Rotation(pitch=8.0))
         ]
-        # 0 is dashcam view; 1 is tethered view
+        # 0 is dashcam view; 1 is tethered view; 2 for spring arm view (manual_control)
         self._transform_index = 0
         self._sensors = [
             ['sensor.camera.rgb', carla.ColorConverter.Raw, 'Camera RGB'],
@@ -114,7 +120,8 @@ class CameraManager(object):
             self.sensor = self._parent.get_world().spawn_actor(
                 self._sensors[index][-1],
                 self._camera_transforms[self._transform_index],
-                attach_to=self._parent)
+                attach_to=self._parent,
+                attachment_type=carla.AttachmentType.Rigid if pos != 2 else carla.AttachmentType.SpringArm)
             # We need to pass the lambda a weak reference to self to avoid
             # circular reference.
             weak_self = weakref.ref(self)

--- a/src/macad_gym/core/sensors/hud.py
+++ b/src/macad_gym/core/sensors/hud.py
@@ -38,29 +38,30 @@ class HUD(object):
         self.frame_number = timestamp.frame_count
         self.simulation_time = timestamp.elapsed_seconds
 
-    def tick(self, world, clock):
+    def tick(self, world, vehicle, collision_sensor, clock):
         if not self._show_info:
             return
-        t = world.vehicle.get_transform()
-        v = world.vehicle.get_velocity()
-        c = world.vehicle.get_vehicle_control()
+
+        t = vehicle.get_transform()
+        v = vehicle.get_velocity()
+        c = vehicle.get_control()
+
         heading = 'N' if abs(t.rotation.yaw) < 89.5 else ''
         heading += 'S' if abs(t.rotation.yaw) > 90.5 else ''
         heading += 'E' if 179.5 > t.rotation.yaw > 0.5 else ''
         heading += 'W' if -0.5 > t.rotation.yaw > -179.5 else ''
-        colhist = world.collision_sensor.get_collision_history()
+        colhist = collision_sensor.get_collision_history()
         collision = [
             colhist[x + self.frame_number - 200] for x in range(0, 200)
         ]
         max_col = max(1.0, max(collision))
         collision = [x / max_col for x in collision]
-        vehicles = world.world.get_actors().filter('vehicle.*')
+        vehicles = world.get_actors().filter('vehicle.*')
         self._info_text = [
             'Server:  % 16d FPS' % self.server_fps,
             'Client:  % 16d FPS' % clock.get_fps(), '',
             'Vehicle: % 20s' %
-            get_actor_display_name(world.vehicle, truncate=20),
-            'Map:     % 20s' % world.world.map_name,
+            get_actor_display_name(vehicle, truncate=20),
             'Simulation time: % 12s' %
             datetime.timedelta(seconds=int(self.simulation_time)), '',
             'Speed:   % 15.0f km/h' %
@@ -81,7 +82,7 @@ class HUD(object):
             #                               (l.y - t.location.y)**2 +
             #                               (l.z - t.location.z)**2)
             vehicles = [(self.distance(x.get_location(), t), x)
-                        for x in vehicles if x.id != world.vehicle.id]
+                        for x in vehicles if x.id != vehicle.id]
             for d, vehicle in sorted(vehicles):
                 if d > 200.0:
                     break

--- a/src/macad_gym/core/sensors/hud.py
+++ b/src/macad_gym/core/sensors/hud.py
@@ -105,12 +105,12 @@ class HUD(object):
         logger.info("Notification error disabled: "+text)
         # self._notifications.set_text('Error: %s' % text, (255, 0, 0))
 
-    def render(self, display):
+    def render(self, display, render_pose=(0,0)):
         if self._show_info:
             info_surface = pygame.Surface((220, self.dim[1]))
             info_surface.set_alpha(100)
-            display.blit(info_surface, (0, 0))
-            v_offset = 4
+            display.blit(info_surface, render_pose)
+            v_offset = 4 + render_pose[1]
             bar_h_offset = 100
             bar_width = 106
             for item in self._info_text:

--- a/src/macad_gym/envs/follow_leading_vehicle.py
+++ b/src/macad_gym/envs/follow_leading_vehicle.py
@@ -1,0 +1,139 @@
+"""
+Author: Morphlng
+Date: 2023-01-28 18:33:26
+LastEditTime: 2023-01-28 18:33:28
+LastEditors: Morphlng
+Description: Example of creating a custom environment, also a demonstration of how to use the manual_control.
+FilePath: \src\macad_gym\envs\follow_leading_vehicle.py
+"""
+
+import random
+from macad_gym.envs import MultiCarlaEnv
+
+"""
+    This is a scenario extracted from Carla/scenario_runner (https://github.com/carla-simulator/scenario_runner/blob/master/srunner/scenarios/follow_leading_vehicle.py).
+
+    The configuration below contains everything you needed to customize your own scenario in Macad-Gym.
+"""
+configs = {
+    "scenarios": {
+        "map": "Town01",
+        "actors": {
+            "car1": {
+                "start": [107, 133, 0.5],
+                "end": [300, 133, 0.5],
+            },
+            "car2": {
+                "start": [115, 133, 0.5],
+                "end": [310, 133, 0.5],
+            }
+        },
+        "num_vehicles": 0,
+        "num_pedestrians": 0,
+        "weather_distribution": [0],
+        "max_steps": 500
+    },
+    "env": {
+        "server_map": "/Game/Carla/Maps/Town01",
+        "render": False,
+        "render_x_res": 800,    # For both Carla-Server and Manual-Control
+        "render_y_res": 600,
+        "x_res": 84,            # Used for camera sensor view size
+        "y_res": 84,
+        "framestack": 1,
+        "discrete_actions": True,
+        "squash_action_logits": False,
+        "verbose": False,
+        "use_depth_camera": False,
+        "send_measurements": False,
+        "enable_planner": True,
+        "spectator_loc": [70, -125, 9],
+        "sync_server": True,
+        "fixed_delta_seconds": 0.05,
+    },
+    "actors": {
+        "car1": {
+            "type": "vehicle_4W",
+            "enable_planner": True,
+            "convert_images_to_video": False,
+            "early_terminate_on_collision": True,
+            "reward_function": "corl2017",
+            "scenarios": "FOLLOWLEADING_TOWN1_CAR1",
+            "manual_control": True,     # manual_control and auto_control
+            "auto_control": True,       # can be turned on at the same time
+            "camera_type": "rgb",
+            "collision_sensor": "on",
+            "lane_sensor": "on",
+            "log_images": False,
+            "log_measurements": False,
+            "render": True,
+            "x_res": 84,    # Deprecated, kept for backward compatibility
+            "y_res": 84,
+            "use_depth_camera": False,
+            "send_measurements": False,
+        },
+        "car2": {
+            "type": "vehicle_4W",
+            "enable_planner": True,
+            "convert_images_to_video": False,
+            "early_terminate_on_collision": True,
+            "reward_function": "corl2017",
+            "scenarios": "FOLLOWLEADING_TOWN1_CAR2",
+            "manual_control": False,
+            "auto_control": True,
+            "camera_type": "rgb",
+            "collision_sensor": "on",
+            "lane_sensor": "on",
+            "log_images": False,
+            "log_measurements": False,
+            "render": True,
+            "x_res": 84,
+            "y_res": 84,
+            "use_depth_camera": False,
+            "send_measurements": False,
+        }
+    },
+}
+
+
+class FollowLeadingVehicle(MultiCarlaEnv):
+    """A two car Multi-Agent Carla-Gym environment"""
+
+    def __init__(self):
+        self.configs = configs
+        super(FollowLeadingVehicle, self).__init__(self.configs)
+
+
+if __name__ == "__main__":
+    env = FollowLeadingVehicle()
+
+    for ep in range(2):
+        obs = env.reset()
+
+        total_reward_dict = {}
+        action_dict = {}
+
+        env_config = configs["env"]
+        actor_configs = configs["actors"]
+        for actor_id in actor_configs.keys():
+            total_reward_dict[actor_id] = 0
+            if env_config['discrete_actions']:
+                # take random action
+                # The action will be ignored if the actor is controlled by auto_control/manual_control
+                action_dict[actor_id] = random.randint(0, 8)
+            else:
+                action_dict[actor_id] = [1, 0]  # test values
+
+        i = 0
+        done = {"__all__": False}
+        while not done["__all__"]:
+            i += 1
+            obs, reward, done, info = env.step(action_dict)
+
+            for actor_id in total_reward_dict.keys():
+                total_reward_dict[actor_id] += reward[actor_id]
+
+            print("Episode: {}, Step: {}, Reward: {}, Done: {}".format(
+                ep, i, total_reward_dict, done))
+
+    env.close()

--- a/src/macad_gym/envs/follow_leading_vehicle.py
+++ b/src/macad_gym/envs/follow_leading_vehicle.py
@@ -1,10 +1,6 @@
 """
-Author: Morphlng
-Date: 2023-01-28 18:33:26
-LastEditTime: 2023-01-28 18:33:28
-LastEditors: Morphlng
-Description: Example of creating a custom environment, also a demonstration of how to use the manual_control.
-FilePath: \src\macad_gym\envs\follow_leading_vehicle.py
+follow_leading_vehicle.py: Example of creating a custom environment, also a demonstration of how to use the manual_control.
+__author__: Morphlng
 """
 
 import random
@@ -13,7 +9,7 @@ from macad_gym.envs import MultiCarlaEnv
 """
     This is a scenario extracted from Carla/scenario_runner (https://github.com/carla-simulator/scenario_runner/blob/master/srunner/scenarios/follow_leading_vehicle.py).
 
-    The configuration below contains everything you needed to customize your own scenario in Macad-Gym.
+    The configuration below contains everything you need to customize your own scenario in Macad-Gym.
 """
 configs = {
     "scenarios": {
@@ -59,8 +55,15 @@ configs = {
             "early_terminate_on_collision": True,
             "reward_function": "corl2017",
             "scenarios": "FOLLOWLEADING_TOWN1_CAR1",
-            "manual_control": True,     # manual_control and auto_control
-            "auto_control": True,       # can be turned on at the same time
+            
+            # When "auto_control" is True,
+            # starts the actor using auto-pilot.
+            # Allows manual control take-over on
+            # pressing Key `p` on the PyGame window
+            # if manual_control is also True
+            "manual_control": True,
+            "auto_control": True,
+
             "camera_type": "rgb",
             "collision_sensor": "on",
             "lane_sensor": "on",

--- a/src/macad_gym/viz/render.py
+++ b/src/macad_gym/viz/render.py
@@ -58,7 +58,6 @@ class Render:
             screen.blit(surface, render_pose)
 
         pygame.display.flip()
-        Render.dummy_event_handler()
 
     @staticmethod
     def get_surface_poses(unit_dimension, actor_configs):
@@ -70,7 +69,7 @@ class Render:
 
         Returns:
             poses (dict): return position dicts in pygame window (start from left corner). E.g., {"vehiclie":[0,0]}
-            window_dim (list): return the max (width, height) needed to render all actors.
+            window_dim (list): return the max [width, height] needed to render all actors.
         """
         unit_x = unit_dimension[0]
         unit_y = unit_dimension[1]
@@ -79,7 +78,7 @@ class Render:
         for _, config in actor_configs.items():
             if config["render"] == True:
                 subwindow_num += 1
-        
+
         if subwindow_num == 0:
             return {}, [0, 0]
 
@@ -154,36 +153,3 @@ class Render:
             if event.type == pygame.QUIT:
                 pygame.quit()
                 exit()
-
-
-if __name__ == "__main__":
-    from random import randint
-
-    resX, resY = 800, 600
-
-    # create a red image as main window
-    image = pygame.Surface((resX, resY))
-    image.fill((255, 0, 0))
-
-    # create four sub surface, each 84x84
-    subwindow_num = 4
-    unit_dimension = [84, 84]
-
-    subwindows = {}
-
-    # fill subwindows with random color
-    for i in range(subwindow_num):
-        surf = pygame.Surface((unit_dimension[0], unit_dimension[1]))
-        surf.fill((randint(0, 255), randint(0, 255), randint(0, 255)))
-        subwindows[i] = surf
-
-    # Generate subwindow_num of pseudo actor_config
-    actor_config = {i: {"render": True} for i in range(subwindow_num)}
-
-    poses, window_dim = Render.get_surface_poses(unit_dimension, actor_config)
-
-    Render.resize_screen(max(resX, window_dim[0]), resY + window_dim[1])
-
-    while True:
-        Render.draw(image, (0, window_dim[1]))
-        Render.multi_view_render(subwindows, poses)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,80 @@
+import math
+from macad_gym.viz.render import Render
+
+def test_resize():
+    """Test resize_screen() and get_screen()
+    """
+    resX, resY = 800, 600
+    Render.resize_screen(resX, resY)
+
+    # The screen should be None before calling get_screen() at the first time
+    assert Render._screen is None
+    assert Render._update_size is True
+
+    screen = Render.get_screen()
+
+    # get_screen will update _screen and _update_size
+    assert screen.get_size() == (resX, resY)
+    assert Render._update_size is False
+
+def test_window_size_1():
+    """Test window size when subwindow's max width
+    smaller than main window's width
+    """
+    resX, resY = 640, 480
+
+    # This is the main image, representing manual_control view
+    Render.resize_screen(resX, resY)
+
+    # This is the sub image, representing the view of the agent
+    subwindow_num = 4
+    unit_dimension = [84, 84]   # 84 * 4 = 336 < 640
+
+    # Generate subwindow_num of pseudo actor_config
+    actor_config = {i: {"render": True} for i in range(subwindow_num)}
+
+    _, window_dim = Render.get_surface_poses(unit_dimension, actor_config)
+
+    # The window_dim should be [336, 84], i.e. 1 row
+    assert window_dim == [336, 84]
+
+
+def test_window_size_2():
+    """Test window size when subwindow's max width
+    larger than main window's width
+    """
+    resX, resY = 240, 120
+
+    # This is the main image, representing manual_control view
+    Render.resize_screen(resX, resY)
+
+    # This is the sub image, representing the view of the agent
+    subwindow_num = 4
+    unit_dimension = [84, 84]   # 84 * 4 = 336 > 240
+
+    # Generate subwindow_num of pseudo actor_config
+    actor_config = {i: {"render": True} for i in range(subwindow_num)}
+
+    _, window_dim = Render.get_surface_poses(unit_dimension, actor_config)
+
+    rows = math.ceil(math.sqrt(subwindow_num))
+
+    # The window_dim should be [168, 168], i.e. 2 row
+    assert window_dim == [unit_dimension[0] * rows, unit_dimension[1] * rows]
+
+
+def test_window_size_3():
+    """Test window size when no subwindow
+    """
+    resX, resY = 640, 480
+
+    # This is the main image, representing manual_control view
+    Render.resize_screen(resX, resY)
+
+    # This is the sub image, representing the view of the agent
+    unit_dimension = [84, 84]   # 84 * 4 = 336 > 240
+
+    _, window_dim = Render.get_surface_poses(unit_dimension, {})
+
+    # The window_dim should be [0, 0]
+    assert window_dim == [0, 0]


### PR DESCRIPTION
# Description

**!! Still Work In Progress**

We are trying to apply some of our new scenarios to macad-gym and manual control is needed to do the basic scene testing. However, the manual_control feature in macad-gym is completely broken, so I did some changes to make it work. Currently, **it's working again, but I still have some questions**.

# Code changes

## 1. MultiCarlaEnv

1. First of all, if manual control is activated, other render options should be turned off, since PyGame does not allow creating multiple windows in one python process. I'm raising an exception if this kind of conflict occurs, but it is possible to just disable camera render for the user. I wonder what is the best practice in your opinion?

2. Secondly, the whole `_on_render` function doesn't make any sense, or at least, it was called in a wrong place. This function used to be called in `manual_control` branch in `_step` method, so it should display the view for user to control the vehicle. However, it renders all the camera frame in `self._cameras`.

    That brings us to another problem, there isn't actually a camera set up for manual_control right now. The camera bind to an actor is the front camera with 84x84 resolution (default scenario), and the `render_x/y_res` argument used in `manual_control` branch is missing in actor_config. 

    I created some new variable to hold the value needed by manual_control, including:

    ```python
        # For manual_control
        self._display = None
        self._control_clock = None
        self._manual_controller = None
        self._manual_control_camera_manager = None
    ```

    The `_on_render` function is not used right now, because I think it is confusing for people who uses the env to figure out what is the return representing. I think all render related code should be moved to a dedicated class (including the camera_render to deal with the problem I [issued](https://github.com/praveen-palanisamy/macad-gym/issues/72#issue-1457526010) earlier).

## 2. KeyboardControl

This class seems to be copied and modified from Carla's manual_control.py script. The `actor_id` is confusing, it is the name of the actor when creating the Controller, but compared to 1, 2, -1 when parsing keys. I assume this code is meant to be cleaned up but somehow forgotten. I also don't know the difference between those three `parse_keys` functions, so I kept the code for now and use only the default control.

https://github.com/praveen-palanisamy/macad-gym/blob/912944cd93c4db2f704f2818d469425fe191f976/src/macad_gym/core/controllers/keyboard_control.py#L82-L89

## 3. CameraManager & HUD

CameraManager holds the camera, but there isn't an appropriate transform for manual_control right now. I've added a SpringArm transform copied from Carla manual_contrl.py.

HUD is not used a lot (or maybe completely not used?) in macad-gym, so the code is basically not working, especially the `tick` function. The `world` parameter is a wrapper in the original Carla script, but we didn't use it. Now I'm passing everything it needed to update the info, but I'm not satisfied with this solution, do you have any suggestion?

# TODO

1. Move all render related function to a class.
2. Reviewing the code, I found that there are a lot of unused codes or even files. Do we still need to keep them?
3. We are trying to integrate [scenario_runner](https://github.com/carla-simulator/scenario_runner) into macad-gym, but the scenario description, resource management are very different. Any advice on this?